### PR TITLE
acceso a exploradores en la consola de despegue.

### DIFF
--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -95,7 +95,8 @@
 	                    SKILL_WEAPONS     = SKILL_EXPERT)
 
 	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage,
-		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_expedition_shuttle_helm,
+		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, 
+		access_expedition_shuttle_helm,
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management)

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -95,7 +95,7 @@
 	                    SKILL_WEAPONS     = SKILL_EXPERT)
 
 	access = list(access_explorer, access_maint_tunnels, access_eva, access_emergency_storage,
-		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
+		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar, access_expedition_shuttle_helm,
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management)


### PR DESCRIPTION
Esto es para los casos donde no haya un shuttle pilot presente y uno de los exploradores tenga el conocimiento de manejar la nave, también cabe la posibilidad de que haya algún minero experto en pilotaje y al menos se le dará más facilidad para conducir la Gaunt teniendo una ID de un explorador.
