### PR TITLE
Ligero agregado, cargo/almacen

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -5307,6 +5307,8 @@
 	},
 /obj/item/stack/nanopaste,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/trauma,
+/obj/item/bodybag/rescue,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "jo" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -14410,6 +14410,7 @@
 	},
 /obj/item/stack/nanopaste,
 /obj/item/bodybag/rescue/loaded,
+/obj/item/weapon/storage/firstaid/trauma,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "aMC" = (


### PR DESCRIPTION
Simplemente agrega a la caja de medicinas, del almacén de cargo (deck 5) y a las del almacén de emergencia (deck 1), un botiquin de trauma. 

¿Por que? Porque no sirve de nada una caja de medicinas si no tenes algo para los traumas.