### PR TITLE
2 Laboratory Technicians

### DIFF
--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -136,8 +136,8 @@
 	title = "Laboratory Technician"
 	department = "Medical"
 	department_flag = MED
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Chief Medical Officer, the Corporate Liaison and Medical Personnel"
 	selection_color = "#013d3b"
 	economic_power = 4


### PR DESCRIPTION
## ¿Qué hace este PR?
Aumenta el slot del Laboratory Technician.

## ¿Por qué es algo bueno para el juego?
Puesto que había espacio para 2 Laboratorys Technicians, me extrañaba que solo hubiese slot para 1, por lo cual he decidido a aumentarlo a 2.

## Changelog
:cl:
tweak: 2 Laboratory Techs
/:cl:

![original](https://user-images.githubusercontent.com/53350410/86541218-7d8a9100-bf0b-11ea-96eb-7fe070d42c53.gif)
![giphy](https://user-images.githubusercontent.com/53350410/86541235-972bd880-bf0b-11ea-8dc9-872f217ed254.gif)
