### PR TITLE
Nanomeds y medicinas de mas

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -904,26 +904,50 @@
 	req_access = list(list(access_medical,access_chemistry))
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
 	req_access = list(access_medical_equip)
-	products = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine = 5,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane = 5,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene = 5,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin = 5,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 3,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline = 3,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline = 3,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/antirad = 3,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/alkysine = 3,
+	products = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine = 3,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane = 3,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene = 3,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin = 3,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/antirad = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/alkysine = 2,
 					/obj/item/weapon/reagent_containers/syringe/antiviral = 5,
 					/obj/item/stack/medical/advanced/bruise_pack = 5,
 					/obj/item/stack/medical/advanced/ointment = 5,
 					/obj/item/stack/medical/splint = 5,
 					/obj/item/device/scanner/health = 5)
 	contraband = list(/obj/item/weapon/reagent_containers/pill/stox = 5,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/combatpain = 3,
-					/obj/item/weapon/reagent_containers/hypospray/autoinjector/peridaxon = 3,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/combatpain = 1,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/peridaxon = 1,
 					/obj/item/weapon/reagent_containers/hypospray/autoinjector/hypeross = 1,
 					/obj/item/weapon/reagent_containers/hypospray/autoinjector/kompoton = 1)
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
+
+/obj/machinery/vending/medical/abandonado
+	name = "NanoMed Plus abandonado"
+	desc = "Un dispensador de medicinas abandonad. Te preguntas si aun tendra algo."
+	icon_state = "med"
+	icon_deny = "med-deny"
+	icon_vend = "med-vend"
+	vend_delay = 18
+	base_type = /obj/machinery/vending/medical
+	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
+	req_access = list(access_medical_equip)
+	products = list(/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane = 1,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin = 1,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pain = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/inaprovaline = 1,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/antirad = 2,
+					/obj/item/weapon/reagent_containers/hypospray/autoinjector/alkysine = 1,
+					/obj/item/weapon/reagent_containers/syringe/antiviral = 2,
+					/obj/item/stack/medical/advanced/bruise_pack = 3,
+					/obj/item/stack/medical/advanced/ointment = 2,
+					/obj/item/stack/medical/splint = 2,
+					/obj/item/device/scanner/health = 1)
+	idle_power_usage = 211
 
 
 //This one's from bay12
@@ -943,14 +967,12 @@
 	icon_deny = "wallmed-deny"
 	icon_vend = "wallmed-vend"
 	base_type = /obj/machinery/vending/wallmed1
-	req_access = list(access_medical_equip)
 	density = 0 //It is wall-mounted, and thus, not dense. --Superxpdude
 	products = list(
-		/obj/item/weapon/storage/med_pouch/trauma,
-		/obj/item/weapon/storage/med_pouch/burn,
-		/obj/item/weapon/storage/med_pouch/oxyloss,
-		/obj/item/weapon/storage/med_pouch/toxin,
-		/obj/item/weapon/storage/med_pouch/radiation
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin
 		)
 
 /obj/machinery/vending/wallmed2
@@ -963,11 +985,10 @@
 	density = 0 //It is wall-mounted, and thus, not dense. --Superxpdude
 	base_type = /obj/machinery/vending/wallmed2
 	products = list(
-		/obj/item/weapon/storage/med_pouch/trauma,
-		/obj/item/weapon/storage/med_pouch/burn,
-		/obj/item/weapon/storage/med_pouch/oxyloss,
-		/obj/item/weapon/storage/med_pouch/toxin,
-		/obj/item/weapon/storage/med_pouch/radiation
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/bicaridine,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/kelotane,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dylovene,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin
 		)
 
 /obj/machinery/vending/security

--- a/code/game/objects/structures/crates_lockers/med_crate.dm
+++ b/code/game/objects/structures/crates_lockers/med_crate.dm
@@ -6,7 +6,6 @@
 /obj/structure/closet/crate/med_crate/trauma/WillContain()
 	return list(
 		/obj/item/stack/medical/splint = 4,
-		/obj/item/weapon/storage/pill_bottle/inaprovaline,
 		/obj/item/weapon/storage/med_pouch/trauma = 4,
 		/obj/item/weapon/storage/firstaid/trauma,
 		/obj/item/weapon/storage/pill_bottle/bicaridine
@@ -19,7 +18,6 @@
 
 /obj/structure/closet/crate/med_crate/burn/WillContain()
 	return list(
-		/obj/item/weapon/storage/pill_bottle/inaprovaline,
 		/obj/item/weapon/storage/med_pouch/burn = 4,
 		/obj/item/weapon/storage/firstaid/fire,
 		/obj/item/weapon/storage/pill_bottle/dermaline
@@ -32,7 +30,6 @@
 
 /obj/structure/closet/crate/med_crate/oxyloss/WillContain()
 	return list(
-		/obj/item/weapon/storage/pill_bottle/inaprovaline,
 		/obj/item/weapon/storage/med_pouch/oxyloss = 4,
 		/obj/item/weapon/storage/firstaid/o2,
 		/obj/item/weapon/storage/pill_bottle/dexalin_plus
@@ -44,7 +41,6 @@
 
 /obj/structure/closet/crate/med_crate/toxin/WillContain()
 	return list(
-		/obj/item/weapon/storage/pill_bottle/inaprovaline,
 		/obj/item/weapon/storage/med_pouch/toxin = 4,
 		/obj/item/weapon/storage/firstaid/toxin,
 		/obj/item/weapon/storage/pill_bottle/dylovene

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -782,7 +782,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/machinery/vending/medical/torch{
+/obj/machinery/vending/medical/abandonado{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1010,14 +1010,9 @@
 	desc = "F8F8F8"
 	},
 /obj/structure/closet/crate/medical,
-/obj/item/weapon/storage/firstaid/trauma,
-/obj/item/weapon/storage/firstaid/fire,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/weapon/storage/firstaid/toxin,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/weapon/storage/firstaid/adv,
 /obj/item/weapon/storage/firstaid/stab,
-/obj/item/stack/nanopaste,
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"


### PR DESCRIPTION
-Modifica la cantidad de Autoinyectores del Nanomed
   -3 Autoinjectores de los principales
   -2 Autoinjectores para los demas
   -Elimina la Adrenalina
   -1 en cada Autoinyector de contrabando

-Modifica el contenido de los nanomed de pared, ahora tienen solo un autoinjector de los 4 principales

-Agrega un Nanomed abandonado ubicado en la enfermeria abandonada del deck 4, con la mitad o menos de autoinyectores, sin acceso requerido y sin contrabando.

-Elimina pastillas de inaprovaline de las cajas y coloca una en la mesa junto a las demas pastillas.