### PR TITLE
PR de Nut (Implante de ingeniería adherente)

### DIFF
--- a/code/modules/augment/active/tool/surgical.dm
+++ b/code/modules/augment/active/tool/surgical.dm
@@ -9,9 +9,7 @@
 		/obj/item/weapon/hemostat,
 		/obj/item/weapon/retractor,
 		/obj/item/weapon/scalpel,
-		/obj/item/weapon/surgicaldrill,
-		/obj/item/weapon/bonegel,
-		/obj/item/weapon/FixOVein
+		/obj/item/weapon/surgicaldrill
 	)
 
 /obj/item/organ/internal/augment/active/polytool/surgical/left
@@ -19,3 +17,22 @@
 
 /obj/item/organ/internal/augment/active/polytool/surgical/right
 	allowed_organs = list(BP_AUGMENT_R_ARM)
+
+/obj/item/organ/internal/augment/active/polytool/adherenttool
+	name = "herramientas adherentes"
+	action_button_name = "Desplegar Herramienta Cristalina"
+	desc = "Este aumento cristalino, implantado en varias unidades adherentes especializadas, contiene todo lo que un ingeniero podria necesitar."
+	paths = list(
+		/obj/item/weapon/weldingtool/electric/crystal,
+		/obj/item/weapon/wirecutters/crystal,
+		/obj/item/weapon/screwdriver/crystal,
+		/obj/item/weapon/crowbar/crystal,
+		/obj/item/weapon/wrench/crystal,
+		/obj/item/device/multitool/crystal
+	)
+/obj/item/organ/internal/augment/active/polytool/adherenttool/left
+	allowed_organs = list(BP_AUGMENT_L_ARM)
+
+/obj/item/organ/internal/augment/active/polytool/adherenttool/right
+	allowed_organs = list(BP_AUGMENT_R_ARM)
+	

--- a/maps/torch/loadout/loadout_augments.dm
+++ b/maps/torch/loadout/loadout_augments.dm
@@ -25,4 +25,13 @@
 /datum/gear/augmentation/implanted_circuitkit/right
 	display_name = "circuit augment - right arm (ROBOTIC)"
 	path = /obj/item/organ/internal/augment/active/simple/circuit/right
-	
+
+/datum/gear/augmentation/implante_cristalino
+	display_name = "Implante de ingenieria adherente - Filamento IZQUIERDO"
+	path = /obj/item/organ/internal/augment/active/polytool/adherenttool/left
+	cost = 4
+	whitelisted = list(SPECIES_ADHERENT)
+
+/datum/gear/augmentation/implante_cristalino/right
+	display_name = "Implante de ingenieria adherente - Filamento DERECHO"
+	path = /obj/item/organ/internal/augment/active/polytool/adherenttool/right


### PR DESCRIPTION

## ¿Qué hace este PR?
Añade un implante en el loadout de herramientas de ingenieria adherente (Exclusivo solo para adherentes)

## ¿Por qué es algo bueno para el juego?
Bueno, los orgánicos-Ipc's tienen la posibilidad de ponerse en sus brazos cibernéticos, herramientas de ingenieria, circuit implanters o de cirugía, a lo cual no veo nada negativo que los adherents tengan la posibilidad de portar sus propias herramientas.

## Images of changes
![image](https://user-images.githubusercontent.com/53350410/90303043-d6562d80-deaa-11ea-8f0a-9bd6cac6215f.png)
![image](https://user-images.githubusercontent.com/53350410/90303045-d8b88780-deaa-11ea-93b8-1af580650fc4.png)
![image](https://user-images.githubusercontent.com/53350410/90303047-dc4c0e80-deaa-11ea-9e77-a03cbc939cd6.png)


## Changelog
:cl:
add: Se pone un implante de ingeniería adherente en el Loadout
/:cl:
