### PR TITLE
Implante de herramientas quirurjicas completo

### DIFF
--- a/code/modules/augment/active/tool/surgical.dm
+++ b/code/modules/augment/active/tool/surgical.dm
@@ -4,6 +4,7 @@
 	desc = "Part of Zeng-Hu Pharmaceutical's line of biomedical augmentations, this device contains the full set of tools any surgeon would ever need."
 	paths = list(
 		/obj/item/weapon/bonesetter,
+		/obj/item/weapon/bonegel,
 		/obj/item/weapon/cautery,
 		/obj/item/weapon/circular_saw,
 		/obj/item/weapon/hemostat,
@@ -35,4 +36,3 @@
 
 /obj/item/organ/internal/augment/active/polytool/adherenttool/right
 	allowed_organs = list(BP_AUGMENT_R_ARM)
-	


### PR DESCRIPTION
Agrega el gel para huesos al implante para que este completo.

Ya EsTaBa PeRo sE BOrRo PoR SubiR El DM dEsAcTuAlIZaDo.