### PR TITLE
Más sonidos a los emotes

### DIFF
--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -15,11 +15,24 @@
 /decl/emote/audible/whimper
 	key ="whimper"
 	emote_message_3p = "USER whimpers."
+/decl/emote/audible/whimper/do_extra(var/atom/user)
+	if(iscarbon(user)) //Citadel Edit because this is hilarious
+		var/mob/living/carbon/C = user
+		if(C.gender == FEMALE)
+			playsound(C.loc,pick( 'sound/emotes_skyrat/whimper_f1','sound/emotes_skyrat/whimper_f2' 50, 1))
 
 /decl/emote/audible/gasp
 	key ="gasp"
 	emote_message_3p = "USER gasps."
 	conscious = 0
+/decl/emote/audible/gasp/do_extra(var/atom/user)
+	if(iscarbon(user)) //Citadel Edit because this is hilarious
+		var/mob/living/carbon/C = user
+		if(C.gender == FEMALE)
+			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_f1','sound/emotes_skyrat/gasp_f2','sound/emotes_skyrat/gasp_f3','sound/emotes_skyrat/gasp_f4','sound/emotes_skyrat/gasp_f5','sound/emotes_skyrat/gasp_f6' 50, 1))
+		else(C.gender == MALE)
+			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_m1','sound/emotes_skyrat/gasp_m2','sound/emotes_skyrat/gasp_m3','sound/emotes_skyrat/gasp_m4','sound/emotes_skyrat/gasp_m5','sound/emotes_skyrat/gasp_m6' 50, 1))
+
 
 /decl/emote/audible/scretch
 	key ="scretch"
@@ -70,6 +83,13 @@
 /decl/emote/audible/sniff
 	key = "sniff"
 	emote_message_3p = "USER sniffs."
+/decl/emote/audible/sniff/do_extra(var/atom/user)
+	if(iscarbon(user)) //Citadel Edit because this is hilarious
+		var/mob/living/carbon/C = user
+		if(C.gender == FEMALE)
+			playsound(C.loc 'sound/emotes_skyrat/female_sniff', 50, 1)
+		if(C.gender == MALE)
+			playsound(C.loc 'sound/emotes_skyrat/male_sniff', 50, 1))
 
 /decl/emote/audible/snore
 	key = "snore"
@@ -96,6 +116,13 @@
 	key = "cough"
 	emote_message_3p = "USER coughs!"
 	conscious = 0
+/decl/emote/audible/cough/do_extra(var/atom/user)
+	if(iscarbon(user)) //Citadel Edit because this is hilarious
+		var/mob/living/carbon/C = user
+		if(C.gender == FEMALE)
+			playsound(C.loc,pick 'sound/emotes_skyrat/female_cough_1','sound/emotes_skyrat/female_cough_2','sound/emotes_skyrat/female_cough_3', 50, 1))
+		if(C.gender == MALE)
+			playsound(C.loc,pick 'sound/emotes_skyrat/male_cough_1','sound/emotes_skyrat/male_cough_2','sound/emotes_skyrat/male_cough_3', 50, 1))
 
 /decl/emote/audible/cry
 	key = "cry"
@@ -119,7 +146,7 @@
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
 			playsound(C.loc, 'sound/voice/human/womanlaugh.ogg', 50, 1)
-		else
+		else(C.gender == MALE)
 			playsound(C.loc,pick ('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg', 50, 1))
 
 /decl/emote/audible/mumble
@@ -143,6 +170,11 @@
 /decl/emote/audible/giggle
 	key = "giggle"
 	emote_message_3p = "USER giggles."
+/decl/emote/audible/giggle/do_extra(var/atom/user)
+	if(iscarbon(user)) //Citadel Edit because this is hilarious
+		var/mob/living/carbon/C = user
+		if(C.gender == FEMALE)
+			playsound(C.loc,pick ('sound/emotes_skyrat/female_giggle_1','sound/emotes_skyrat/female_giggle_2', 50, 1))
 
 /decl/emote/audible/scream
 	key = "scream"

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -19,7 +19,7 @@
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc,pick( 'sound/emotes_skyrat/whimper_f1','sound/emotes_skyrat/whimper_f2', 50, 1))
+			playsound(C.loc,pick( 'sound/emotes_skyrat/whimper_f1.ogg','sound/emotes_skyrat/whimper_f2.ogg', 50, 1))
 
 /decl/emote/audible/gasp
 	key ="gasp"
@@ -29,9 +29,9 @@
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_f1','sound/emotes_skyrat/gasp_f2','sound/emotes_skyrat/gasp_f3','sound/emotes_skyrat/gasp_f4','sound/emotes_skyrat/gasp_f5','sound/emotes_skyrat/gasp_f6', 50, 1))
-		else(C.gender == MALE)
-			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_m1','sound/emotes_skyrat/gasp_m2','sound/emotes_skyrat/gasp_m3','sound/emotes_skyrat/gasp_m4','sound/emotes_skyrat/gasp_m5','sound/emotes_skyrat/gasp_m6', 50, 1))
+			playsound(C.loc, pick ( 'sound/emotes_skyrat/gasp_f1.ogg','sound/emotes_skyrat/gasp_f2.ogg','sound/emotes_skyrat/gasp_f3.ogg','sound/emotes_skyrat/gasp_f4.ogg','sound/emotes_skyrat/gasp_f5.ogg','sound/emotes_skyrat/gasp_f6.ogg', 50, 1))
+		else
+			playsound(C.loc, pick ( 'sound/emotes_skyrat/gasp_m1.ogg','sound/emotes_skyrat/gasp_m2.ogg','sound/emotes_skyrat/gasp_m3.ogg','sound/emotes_skyrat/gasp_m4.ogg','sound/emotes_skyrat/gasp_m5.ogg','sound/emotes_skyrat/gasp_m6.ogg', 50, 1))
 
 
 /decl/emote/audible/scretch
@@ -122,9 +122,9 @@
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc,pick, ('sound/emotes_skyrat/female_cough_1','sound/emotes_skyrat/female_cough_2','sound/emotes_skyrat/female_cough_3', 50, 1))
-		if(C.gender == MALE)
-			playsound(C.loc,pick, ('sound/emotes_skyrat/male_cough_1','sound/emotes_skyrat/male_cough_2','sound/emotes_skyrat/male_cough_3', 50, 1))
+			playsound(C.loc,pick ('sound/emotes_skyrat/female_cough_1.ogg','sound/emotes_skyrat/female_cough_2.ogg','sound/emotes_skyrat/female_cough_3.ogg', 50, 1))
+		else
+			playsound(C.loc,pick ('sound/emotes_skyrat/male_cough_1.ogg','sound/emotes_skyrat/male_cough_2.ogg','sound/emotes_skyrat/male_cough_3.ogg', 50, 1))
 
 /decl/emote/audible/cry
 	key = "cry"
@@ -148,7 +148,7 @@
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
 			playsound(C.loc, 'sound/voice/human/womanlaugh.ogg', 50, 1)
-		else(C.gender == MALE)
+		else
 			playsound(C.loc,pick ('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg', 50, 1))
 
 /decl/emote/audible/mumble
@@ -176,7 +176,7 @@
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc,pick ('sound/emotes_skyrat/female_giggle_1','sound/emotes_skyrat/female_giggle_2', 50, 1))
+			playsound(C.loc,pick ('sound/emotes_skyrat/female_giggle_1.ogg','sound/emotes_skyrat/female_giggle_2.ogg', 50, 1))
 
 /decl/emote/audible/scream
 	key = "scream"

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -19,7 +19,7 @@
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc,pick( 'sound/emotes_skyrat/whimper_f1','sound/emotes_skyrat/whimper_f2' 50, 1))
+			playsound(C.loc,pick( 'sound/emotes_skyrat/whimper_f1','sound/emotes_skyrat/whimper_f2', 50, 1))
 
 /decl/emote/audible/gasp
 	key ="gasp"
@@ -29,9 +29,9 @@
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_f1','sound/emotes_skyrat/gasp_f2','sound/emotes_skyrat/gasp_f3','sound/emotes_skyrat/gasp_f4','sound/emotes_skyrat/gasp_f5','sound/emotes_skyrat/gasp_f6' 50, 1))
+			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_f1','sound/emotes_skyrat/gasp_f2','sound/emotes_skyrat/gasp_f3','sound/emotes_skyrat/gasp_f4','sound/emotes_skyrat/gasp_f5','sound/emotes_skyrat/gasp_f6', 50, 1))
 		else(C.gender == MALE)
-			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_m1','sound/emotes_skyrat/gasp_m2','sound/emotes_skyrat/gasp_m3','sound/emotes_skyrat/gasp_m4','sound/emotes_skyrat/gasp_m5','sound/emotes_skyrat/gasp_m6' 50, 1))
+			playsound(C.loc,pick( 'sound/emotes_skyrat/gasp_m1','sound/emotes_skyrat/gasp_m2','sound/emotes_skyrat/gasp_m3','sound/emotes_skyrat/gasp_m4','sound/emotes_skyrat/gasp_m5','sound/emotes_skyrat/gasp_m6', 50, 1))
 
 
 /decl/emote/audible/scretch
@@ -83,13 +83,14 @@
 /decl/emote/audible/sniff
 	key = "sniff"
 	emote_message_3p = "USER sniffs."
+
 /decl/emote/audible/sniff/do_extra(var/atom/user)
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc 'sound/emotes_skyrat/female_sniff', 50, 1)
+			playsound(C.loc, 'sound/emotes_skyrat/female_sniff.ogg', 50, 1)
 		if(C.gender == MALE)
-			playsound(C.loc 'sound/emotes_skyrat/male_sniff', 50, 1))
+			playsound(C.loc, 'sound/emotes_skyrat/male_sniff.ogg', 50, 1)
 
 /decl/emote/audible/snore
 	key = "snore"
@@ -116,13 +117,14 @@
 	key = "cough"
 	emote_message_3p = "USER coughs!"
 	conscious = 0
+
 /decl/emote/audible/cough/do_extra(var/atom/user)
 	if(iscarbon(user)) //Citadel Edit because this is hilarious
 		var/mob/living/carbon/C = user
 		if(C.gender == FEMALE)
-			playsound(C.loc,pick 'sound/emotes_skyrat/female_cough_1','sound/emotes_skyrat/female_cough_2','sound/emotes_skyrat/female_cough_3', 50, 1))
+			playsound(C.loc,pick, ('sound/emotes_skyrat/female_cough_1','sound/emotes_skyrat/female_cough_2','sound/emotes_skyrat/female_cough_3', 50, 1))
 		if(C.gender == MALE)
-			playsound(C.loc,pick 'sound/emotes_skyrat/male_cough_1','sound/emotes_skyrat/male_cough_2','sound/emotes_skyrat/male_cough_3', 50, 1))
+			playsound(C.loc,pick, ('sound/emotes_skyrat/male_cough_1','sound/emotes_skyrat/male_cough_2','sound/emotes_skyrat/male_cough_3', 50, 1))
 
 /decl/emote/audible/cry
 	key = "cry"


### PR DESCRIPTION
## ¿Qué hace este PR?
Añade sonidos a los siguientes emotes: cough, sniff, gasp, whimper y giggle

## ¿Por qué es algo bueno para el juego?
Añade más inmersión al juego.

## Changelog
:cl:
soundadd: 6 coughs para mujeres.
soundadd: 6 coughs para hombres.
soundadd: 2 whimpers para mujeres
soundadd: 1 sniff para mujer
soundadd: 1 sniff para hombre
soundadd: 2 giggles para mujer
/:cl:

![10e46127d03e464a962f8833af33ff3a](https://user-images.githubusercontent.com/53350410/90931953-f2535500-e3fd-11ea-9cc7-42a4d13fef76.gif)

