### PR TITLE
Cambios en numero de readys

### DIFF
--- a/code/game/gamemodes/calamity/calamity.dm
+++ b/code/game/gamemodes/calamity/calamity.dm
@@ -5,8 +5,8 @@
 	round_description = "This must be a Thursday. You never could get the hang of Thursdays..."
 	extended_round_description = "All hell is about to break loose. Literally every antagonist type may spawn in this round. Hold on tight."
 	config_tag = "calamity"
-	required_players = 45
-	votable = 1
+	required_players = 25
+	votable = 0
 	event_delay_mod_moderate = 0.5
 	event_delay_mod_major = 0.75
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -11,8 +11,7 @@
 		No one knows where it came from. No one knows who it is or what it wants. One thing is for \
 		certain though... there is never just one of them. Good luck."
 	config_tag = "changeling"
-	required_players = 2
-	required_enemies = 1
+	required_players = 10
 	end_on_antag_death = FALSE
 	antag_scaling_coeff = 10
 	votable = 0

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -3,7 +3,7 @@
 	round_description = "Some crewmembers are attempting to start a cult!"
 	extended_round_description = "There has been an infiltration by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "cult"
-	required_players = 12
-	required_enemies = 4
+	required_players = 14
+	votable = 0
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CULTIST)

--- a/code/game/gamemodes/godmode/godmode.dm
+++ b/code/game/gamemodes/godmode/godmode.dm
@@ -3,7 +3,7 @@
 	round_description = "An otherworldly beast has turned its attention to you and your fellow cremembers."
 	extended_round_description = "The station has been infiltrated by a fanatical group of death-cultists! They will use powers from beyond your comprehension to subvert you to their cause and ultimately please their gods through sacrificial summons and physical immolation! Try to survive!"
 	config_tag = "god"
-	required_players = 10
-	required_enemies = 3
+	required_players = 16
+	votable = 0
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_DEITY, MODE_GODCULTIST)

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -5,8 +5,8 @@
 /datum/game_mode/heist
 	name = "Heist"
 	config_tag = "heist"
-	required_players = 6
-	required_enemies = 3
+	required_players = 12
+	votable = 0
 	round_description = "An unidentified bluespace signature has slipped into close sensor range and is approaching!"
 	extended_round_description = "The Company's majority control of phoron in Nyx has marked the \
 		station to be a highly valuable target for many competing organizations and individuals. Being a \

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -3,13 +3,12 @@
 	round_description = "The AI is behaving abnormally and must be stopped."
 	extended_round_description = "The AI will attempt to hack the APCs in order to gain as much control as possible."
 	config_tag = "malfunction"
-	required_players = 2
-	required_enemies = 1
+	required_players = 18
+	votable = 0
 	end_on_antag_death = FALSE
 	auto_recall_shuttle = FALSE
 	antag_tags = list(MODE_MALFUNCTION)
 	disabled_jobs = list("AI")
-	votable = 0
 	cinematic_icon_states = list(
 		"intro_malf" = 76,
 		"summary_malf",

--- a/code/game/gamemodes/mixed/crossfire.dm
+++ b/code/game/gamemodes/mixed/crossfire.dm
@@ -3,8 +3,9 @@
 	round_description = "Mercenaries and raiders are preparing for a nice visit..."
 	extended_round_description = "Nothing can possibly go wrong with lots of people and lots of guns, right?"
 	config_tag = "crossfire"
-	required_players = 14
+	required_players = 30
 	required_enemies = 6
+	votable = 0
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_RAIDER, MODE_MERCENARY)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/siege.dm
+++ b/code/game/gamemodes/mixed/siege.dm
@@ -3,8 +3,9 @@
 	config_tag = "siege"
 	round_description = "Getting stuck between a rock and a hard place, maybe the nice visitors can help with your internal security problem?"
 	extended_round_description = "GENERAL QUARTERS! OH GOD WE GAVE THE REVOLUTIONARIES GUNS!"
-	required_players = 14
+	required_players = 30
 	required_enemies = 4
+	votable = 0
 	end_on_antag_death = FALSE
 	auto_recall_shuttle = FALSE
 	shuttle_delay = 2

--- a/code/game/gamemodes/mixed/spyvspy.dm
+++ b/code/game/gamemodes/mixed/spyvspy.dm
@@ -3,8 +3,8 @@
 	round_description = "There are traitorous forces at play, but some crew have resolved to stop them by any means necessary!"
 	extended_round_description = "Traitors and renegades both spawn during this mode."
 	config_tag = "spyvspy"
-	required_players = 4
-	required_enemies = 4
+	required_players = 10
+	votable = 0
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_TRAITOR, MODE_RENEGADE)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/traitorling.dm
+++ b/code/game/gamemodes/mixed/traitorling.dm
@@ -4,7 +4,7 @@
 	extended_round_description = "Traitors and changelings both spawn during this mode."
 	config_tag = "traitorling"
 	required_players = 14
-	required_enemies = 4
+	votable = 0
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_CHANGELING, MODE_TRAITOR)
 	require_all_templates = TRUE

--- a/code/game/gamemodes/mixed/uprising.dm
+++ b/code/game/gamemodes/mixed/uprising.dm
@@ -3,8 +3,8 @@
 	round_description = "Some crewmembers are attempting to start a revolution while a cult plots in the shadows!"
 	extended_round_description = "Cultists and revolutionaries spawn in this round."
 	config_tag = "uprising"
-	required_players = 14
-	required_enemies = 6
+	required_players = 18
+	votable = 0
 	end_on_antag_death = FALSE
 	auto_recall_shuttle = FALSE
 	shuttle_delay = 2

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -9,7 +9,7 @@
 		the omniscience of the AI and rival the most hardened weapons your people are capable of. Tread lightly and \
 		only hope this unknown assassin isn't here for you."
 	config_tag = "ninja"
-	required_players = 5
-	required_enemies = 1
+	required_players = 10
+	votable = 0
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_NINJA)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -12,8 +12,8 @@ var/list/nuke_disks = list()
 		colony of sizable population and considerable wealth causes it to often be the target of various \
 		attempts of robbery, fraud and other malicious actions."
 	config_tag = "mercenary"
-	required_players = 12
-	required_enemies = 6
+	required_players = 18
+	votable = 0
 	end_on_antag_death = FALSE
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -3,8 +3,8 @@
 	config_tag = "revolution"
 	round_description = "Some crewmembers are attempting to start a revolution!"
 	extended_round_description = "Revolutionaries - Remove the heads of staff from power. Convert other crewmembers to your cause using the 'Convert Bourgeoise' verb. Protect your leaders."
-	required_players = 4
-	required_enemies = 3
+	required_players = 14
+	votable = 0
 	auto_recall_shuttle = FALSE
 	end_on_antag_death = FALSE
 	shuttle_delay = 2

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -11,10 +11,9 @@
 		friends and family as they try to use your emotions and trust to their advantage, leaving you with nothing \
 		but the painful reminder that space is cruel and unforgiving."
 	config_tag = "traitor"
-	required_players = 0
-	required_enemies = 1
+	required_players = 8
+	votable = 0
 	antag_tags = list(MODE_TRAITOR)
-	votable = 1
 	antag_scaling_coeff = 5
 	end_on_antag_death = FALSE
 	latejoin_antag_tags = list(MODE_TRAITOR)

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -3,8 +3,7 @@
 	round_description = "There is a SPACE WIZARD onboard. You can't let the magician achieve their objectives!"
 	extended_round_description = "A powerful entity capable of manipulating the elements around him, most commonly referred to as a 'wizard', has made their way onboard. They have a wide variety of powers and spells available to them that makes your own simple moral self tremble with fear and excitement. Ultimately, their purpose is unknown. However, it is up to you and your crew to decide if their powers can be used for good or if their arrival foreshadows devastation."
 	config_tag = "wizard"
-	required_players = 5
-	required_enemies = 1
+	required_players = 20
 	votable = 0
 	end_on_antag_death = FALSE
 	antag_tags = list(MODE_WIZARD)


### PR DESCRIPTION
Cambia el numero de readys necesarios para los distintos modos y deja como votable en round start solo Secret y Extended.

Readys para los modos

Traitor - 8 readys
Spy vs spy -10 readys
Changeling - 10 readys
ninja - 10 readys
Heist - 12 readys
Traitorling 14 readys
Cult - 14 readys
rev - 14 readys
Deity - 16 readys
cultrev - 18 readys
Mercenary - 18 readys
MalfIA - 18 readys
Wizard - 20 readys
calamity - 25 readys
Cossfire - 30 readys
Siege - 30 readys