### PR TITLE
Velocidad y loot de NPC

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -35,8 +35,6 @@
 	projectilesound = 'sound/weapons/laser.ogg'
 	ranged = 1
 	rapid = 0
-	maxHealth = 50
-	health = 50
 	projectiletype = /obj/item/projectile/beam
 	corpse = /obj/effect/landmark/corpse/pirate/ranged
 	weapon1 = /obj/item/weapon/gun/energy/retro

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -5,22 +5,26 @@
 	icon_living = "piratemelee"
 	icon_dead = "piratemelee_dead"
 	speak_chance = 0
-	turns_per_move = 5
+	turns_per_move = 6
 	response_help = "pushes"
 	response_disarm = "shoves"
 	response_harm = "hits"
-	speed = 4
+	speed = 2
 	stop_automated_movement_when_pulled = 0
 	maxHealth = 100
 	health = 100
 	can_escape = TRUE
+
 	harm_intent_damage = 5
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 	attacktext = "slashed"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
+
 	unsuitable_atmos_damage = 15
 	var/corpse = /obj/effect/landmark/corpse/pirate
+	var/weapon1 = /obj/item/weapon/melee/energy/sword/pirate
+
 	faction = "pirate"
 
 /mob/living/simple_animal/hostile/pirate/ranged
@@ -30,14 +34,19 @@
 	icon_dead = "piratemelee_dead"
 	projectilesound = 'sound/weapons/laser.ogg'
 	ranged = 1
-	rapid = 1
+	rapid = 0
+	maxHealth = 50
+	health = 50
 	projectiletype = /obj/item/projectile/beam
 	corpse = /obj/effect/landmark/corpse/pirate/ranged
+	weapon1 = /obj/item/weapon/gun/energy/retro
 
 
 /mob/living/simple_animal/hostile/pirate/death(gibbed, deathmessage, show_dead_message)
 	..(gibbed, deathmessage, show_dead_message)
 	if(corpse)
 		new corpse (src.loc)
+	if(weapon1)
+		new weapon1 (src.loc)
 	qdel(src)
 	return

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -6,11 +6,11 @@
 	icon_dead = "russianmelee_dead"
 	icon_gib = "syndicate_gib"
 	speak_chance = 0
-	turns_per_move = 5
+	turns_per_move = 6
 	response_help = "pokes"
 	response_disarm = "shoves"
 	response_harm = "hits"
-	speed = 4
+	speed = 2
 	stop_automated_movement_when_pulled = 0
 	maxHealth = 100
 	health = 100
@@ -32,6 +32,8 @@
 	icon_living = "russianranged"
 	corpse = /obj/effect/landmark/corpse/russian/ranged
 	ranged = 1
+	maxHealth = 50
+	health = 50
 	projectiletype = /obj/item/projectile/bullet
 	projectilesound = 'sound/weapons/gunshot/gunshot2.ogg'
 

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -6,11 +6,11 @@
 	icon_dead = "syndicate_dead"
 	icon_gib = "syndicate_gib"
 	speak_chance = 0
-	turns_per_move = 5
+	turns_per_move = 6
 	response_help = "pokes"
 	response_disarm = "shoves"
 	response_harm = "hits"
-	speed = 4
+	speed = 2
 	stop_automated_movement_when_pulled = 0
 	maxHealth = 100
 	health = 100
@@ -21,6 +21,7 @@
 	attacktext = "punched"
 	a_intent = I_HURT
 	var/corpse = /obj/effect/landmark/corpse/syndicate
+	var/weapon1
 	unsuitable_atmos_damage = 15
 	environment_smash = 1
 	faction = "syndicate"
@@ -30,6 +31,8 @@
 	..(gibbed, deathmessage, show_dead_message)
 	if(corpse)
 		new corpse (src.loc)
+	if(weapon1)
+		new weapon1 (src.loc)
 	qdel(src)
 	return
 
@@ -40,6 +43,7 @@
 	melee_damage_upper = 25
 	icon_state = "syndicatemelee"
 	icon_living = "syndicatemelee"
+	weapon1 = /obj/item/weapon/melee/energy/sword/red
 	attacktext = "slashed"
 	status_flags = 0
 
@@ -83,8 +87,11 @@
 	rapid = 1
 	icon_state = "syndicateranged"
 	icon_living = "syndicateranged"
+	casingtype = /obj/item/ammo_casing/pistol
 	projectilesound = 'sound/weapons/gunshot/gunshot_smg.ogg'
 	projectiletype = /obj/item/projectile/bullet/pistol
+
+	weapon1 = /obj/item/weapon/gun/projectile/automatic/merc_smg
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space
 	icon_state = "syndicaterangedpsace"

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -140,14 +140,14 @@
 	icon_living = "extremist"
 	icon_dead = "extremist_dead"
 	speak_chance = 0
-	turns_per_move = 5
+	turns_per_move = 6
 	response_help = "pushes"
 	response_disarm = "shoves"
 	response_harm = "hits"
-	speed = 4
+	speed = 2
 	stop_automated_movement_when_pulled = 0
-	maxHealth = 100
-	health = 100
+	maxHealth = 75
+	health = 75
 	harm_intent_damage = 5
 	melee_damage_lower = 10
 	melee_damage_upper = 30
@@ -186,8 +186,8 @@
 	item_icons = list(slot_w_uniform_str = 'maps/away/slavers/slavers_base_sprites.dmi')
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	armor = list(
-		melee = ARMOR_MELEE_KNIVES, 
-		bullet = ARMOR_BALLISTIC_PISTOL, 
-		laser = ARMOR_LASER_MINOR, 
+		melee = ARMOR_MELEE_KNIVES,
+		bullet = ARMOR_BALLISTIC_PISTOL,
+		laser = ARMOR_LASER_MINOR,
 		energy = ARMOR_ENERGY_MINOR
 		)


### PR DESCRIPTION
-Disminuye la velocidad de los NPC Piratas, Rusos y Syndies.

-Les agrega loot al morir.

-Les baja un poco la vida a los que tienen armas de fuego para que no esten tan OP.
