### PR TITLE
Las carabinas de PRACTICA no causan daño (Bay)

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -22,7 +22,7 @@
 
 /obj/item/projectile/beam/practice
 	fire_sound = 'sound/weapons/Taser.ogg'
-	damage = 2
+	damage = 0
 	eyeblur = 2
 
 /obj/item/projectile/beam/smalllaser


### PR DESCRIPTION
## ¿Qué hace este PR?
Le quita el daño a las Carabians de PRACTICA

https://github.com/Baystation12/Baystation12/pull/29205/files

## ¿Por qué es bueno para el juego?
Porque son Carabinas de PRACTICA, no armas.

## Changelog
:cl:
tweak: Daño del rifle de PRACTICA
/:cl: