### PR TITLE
Equipado rapido funciona con ropa interior (Bay)

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -31,6 +31,9 @@ This saves us from having to call add_fingerprint() any time something is put in
 				update_inv_l_hand(0)
 			else
 				update_inv_r_hand(0)
+		else if (istype (I, /obj/item/underwear))
+			var/obj/item/underwear/U = I
+			U.EquipUnderwear(H, H)
 		else
 			to_chat(H, "<span class='warning'>You are unable to equip that.</span>")
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Simplemente hace que la ropa interior se pueda equipar rapido precionando la "E" al tenenerlo en la mano, como el resto de las prendas.
https://github.com/Baystation12/Baystation12/pull/29248/files?file-filters%5B%5D=

## ¿Por qué es bueno para el juego?
Para nada, pero esta en Bay y esta cool.

## Changelog
:cl:
tweak: La ropa interior ahora es equipable rapidamente con la "E"
/:cl: