### PR TITLE
Imprimir ordenes de arresto

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -5,7 +5,7 @@
 	networks = list(NETWORK_SECURITY)
 	subsystems = list(
 		/datum/nano_module/crew_monitor,
-		/datum/nano_module/digitalwarrant
+		/datum/nano_module/program/digitalwarrant
 	)
 	sprites = list(
 		"Drone" = "drone-sec",

--- a/code/modules/mob/living/silicon/robot/modules/module_security.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_security.dm
@@ -7,7 +7,7 @@
 	)
 	subsystems = list(
 		/datum/nano_module/crew_monitor,
-		/datum/nano_module/digitalwarrant
+		/datum/nano_module/program/digitalwarrant
 	)
 	can_be_pushed = FALSE
 	supported_upgrades = list(

--- a/nano/templates/digitalwarrant.tmpl
+++ b/nano/templates/digitalwarrant.tmpl
@@ -75,7 +75,7 @@
 					<tr><td>{{:helper.link('Authorize access', null, {'editwarrantidauth' : 1})}}
 				{{/if}}
 				<tr><td>{{:helper.link('Save', null, {'savewarrant' : 1})}}
-				<td>{{:helper.link('Delete', 'trash', {'deletewarrant' : 1})}}
+				<td>{{:helper.link('Print', null, {'printwarrant' : 1})}} {{:helper.link('Delete', 'trash', {'deletewarrant' : 1})}}
 				<tr><td>{{:helper.link('Back to Menu', null, {'back' : 1})}}
 			</table>
 		</div>


### PR DESCRIPTION
## ¿Qué hace este PR?
Añade a la aplicacion de Warrants de sec la posibilidad de imprimir las ordenes de arrestos.
Porteado de Bay y modificado el papel por mi.
https://github.com/Baystation12/Baystation12/pull/29080

## ¿Por qué es bueno para el juego?
Permite enseñar una orden de arresto cuando en rol lo requiera.

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/92543953-1ba81980-f223-11ea-9b28-04aeef44a4c5.png)
![image](https://user-images.githubusercontent.com/62310132/92543959-1e0a7380-f223-11ea-8b02-2b8f63db9b60.png)

## Changelog
:cl:
add: La posiblidad de imprimir ordenes de arresto
/:cl: